### PR TITLE
fix(clippy): use `LazyLock` instead of `lazy_static`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -102,7 +102,6 @@ dependencies = [
  "eyre",
  "insta",
  "itertools",
- "lazy_static",
  "mktemp",
  "serial_test",
  "thiserror",

--- a/aoc/Cargo.toml
+++ b/aoc/Cargo.toml
@@ -11,7 +11,6 @@ clap = { version = "4.5.26", features = ["derive"] }
 color-eyre = "0.6.3"
 eyre = "0.6.12"
 itertools = "0.14.0"
-lazy_static = "1.5.0"
 mktemp = "0.5.1"
 thiserror = "2.0.11"
 

--- a/aoc/src/runners.rs
+++ b/aoc/src/runners.rs
@@ -1,14 +1,16 @@
 #![allow(clippy::type_complexity)]
 
-use lazy_static::lazy_static;
-use std::{collections::BTreeMap, fmt::Display, sync::Mutex};
+use std::{
+    collections::BTreeMap,
+    fmt::Display,
+    sync::{LazyLock, Mutex},
+};
 
 type Runner = dyn FnOnce() -> eyre::Result<String> + Send + Sync + 'static;
 
-lazy_static! {
-    pub(crate) static ref RUNNERS: Mutex<BTreeMap<(usize, usize), Vec<(Option<String>, Box<Runner>)>>> =
-        Mutex::new(BTreeMap::new());
-}
+pub(crate) static RUNNERS: LazyLock<
+    Mutex<BTreeMap<(usize, usize), Vec<(Option<String>, Box<Runner>)>>>,
+> = LazyLock::new(|| Mutex::new(BTreeMap::new()));
 
 pub fn register_runner<F, T>(day: usize, part: usize, version: Option<String>, func: F)
 where


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Removed an outdated external dependency.
- **Refactor**
	- Updated the initialization approach for shared internal resources to a more modern and maintainable pattern.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->